### PR TITLE
Use winston-daily-rotate-file for logs rotating; added log_dirname

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+
+sftp-config.json

--- a/bin/giver.js
+++ b/bin/giver.js
@@ -12,9 +12,9 @@ commander
 
 const config = require(commander.config); 
 const giver_logger = new logger({
-	filename: 'giver-%Y%m%d.log',
+	filename: 'giver-%DATE%.log',
 	console: commander.daemon === true ? false : true,
-	symlink: 'giver/log'
+	dirname: config.log_dirname || ''
 });
 giver_logger.extend(console);
 config.logger = giver_logger;

--- a/lib/giver.js
+++ b/lib/giver.js
@@ -2,7 +2,7 @@ var async = require('async'),
 	http = require('http'),
 	url = require('url'),
 	https = require('https'),
-	_ = require('lodash'),
+	_ = require('underscore'),
 	fast_bindall = require('fast_bindall'),
 	express = require('express');
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -9,168 +9,130 @@ var Winston      = require('winston'),    // logger of choice by node nerds ever
     Util         = require('util'),
     FS           = require('fs'),
     ChildProcess = require('child_process'),
-	_            = require('underscore'),
-    Strftime     = require('strftime');   // formats timestrings ala strftime :-)
+    _            = require('underscore'),
+    Strftime     = require('strftime'),   // formats timestrings ala strftime :-)
+    winstonDailyRotate = require('winston-daily-rotate-file');
 
-// We need to slightly modify the default File transport provided by Winston
-// in order to handle log rotation.  We'll inherit most of what we need and just 
-// override the filename and open functions
-var RotateFile = function(options) {
-	Winston.transports.File.call(this, options);
-	this.symlink = options.symlink;
+// yo
+
+var fileLoggingOpts = {
+  filename: 'TheGiver' + '-%DATE%.log',
+  datePattern: 'YYYY-MM-DD-HH',
+  zippedArchive: true,
+  maxSize: '20m',
+  maxFiles: '7d',
+  timestamp:   _timestamp,
+  colorize:    false,
+  json:        false,
+  prettyPrint: true,
+  level:       'debug',
+  dirname:     '/var/log'
 };
 
-var log_directory = process.env.LOGTOP || '/var/log';
-
-Util.inherits(RotateFile, Winston.transports.File);
-
-// Change open so that it rotates only when the strftime format in the filename
-// changes
-RotateFile.prototype.open = function(callback) {
-	var filename = this._getFile();
-	if (this.opening) {
-		return callback(true);
-	}
-	else if (!this._stream || (this._currentfilename != filename)) {
-		callback(true);
-		Mkdirp.sync(Path.dirname(filename));
-		if (this.symlink) {
-			var symlink = log_directory + '/' + this.symlink;
-			ChildProcess.exec('ln -fs ' + filename + ' ' + symlink, function(){});
-		}
-		this._currentfilename = filename;
-		return this._createStream();
-	}
-	callback();
-};
-
-// Use strftime to fill out timestamp information in our log files
-RotateFile.prototype._getFile = function() {
-	var filename = this._basename;
-	if (!filename.match(/^\//)) {
-		filename = log_directory + '/' + filename;
-	}
-	this.dirname = '/';
-	return Strftime(filename);
-};
 
 // Main function; here we initiate a baseline console logger based on the types
 // of logging we'll need.  If this is iniaited with a filename, we'll add a 
 // RotateFile transport below.  We also have the option of enabling a transport
 // for criticals that will email us
 function logger(options) {
-	options = !options ? {} : options;
-	var winston_logger = new (Winston.Logger)({ });
-	//console.log(Winston.config.syslog.levels);
-	winston_logger.setLevels(Winston.config.syslog.levels);
+    options = !options ? {} : options;
+    var winston_logger = new (Winston.Logger)({ });
+    //console.log(Winston.config.syslog.levels);
+    winston_logger.setLevels(Winston.config.syslog.levels);
 
-	if (options.console !== false) {
-		winston_logger.add(Winston.transports.Console,
-			{
-				timestamp:        _timestamp,
-				colorize:         true,
-				prettyPrint:      true,
-				level:            'debug'
-			});
-	}
-	if (options.filename && ! options.raw_json) {
-		winston_logger.add(RotateFile,
-			{
-				timestamp:   _timestamp,
-				filename:    options.filename,
-				colorize:    false,
-				json:        false,
-				prettyPrint: true,
-				level:       'debug',
-				symlink:     options.symlink
-			});
-	}
-	if (options.raw_json) {
-		winston_logger.add(RotateFile,
-			{
-				timestamp:   _timestamp,
-				filename:    options.filename,
-				colorize:    false,
-				json:        true,
-				prettyPrint:  false,
-				level:       'debug',
-				symlink:     options.symlink
-			});
-	}
+    if (options.console !== false) {
+        winston_logger.add(Winston.transports.Console,
+            {
+                timestamp:        _timestamp,
+                colorize:         true,
+                prettyPrint:      true,
+                level:            'debug'
+            });
+    }
 
-	// some vodoo here; we want to automagically log a stack trace when error, debug
-	// or critical errors occur.  We essential overwrite the parent class for each
-	// method and at a stack trace
-	var methods = ['debug', 'info', 'notice', 'warning', 'error', 'crit', 'alert', 'emerg'];
-	for (var i in methods) {
-		var method = methods[i];
-		this[method] = winston_logger[method];
-	}
+    fileLoggingOpts.dirname = options.dirname;
 
-	//this.levels = winston_logger.levels;
-	this.log = this.info = function(message, meta, callback) {
-		var log_meta = options.console !== false ? undefined : meta;
-		if (callback) {
-			winston_logger.info(message, callback);
-		}
-		else {
-			winston_logger.info(message);
-		}
-	};
-	this.warn = this.warning;
-	this.err = this.error = function(message, meta, callback) {
-		var stack = _format_stack(message);
-		var log_meta = options.console !== false ? undefined : meta;
-		if (typeof(meta) == "function") {
-			callback = meta;
-		}
-		winston_logger.error(stack[1], log_meta, function() { 
-			winston_logger.debug(stack[0], callback) 
-		});
-	};
-	this.debug = function(message, meta, callback) {
-		var log_meta = options.console !== false ? undefined : meta;
-		if (typeof(meta) == "function") {
-			callback = meta;
-		}
-		var stack = _format_stack(message);
-		winston_logger.debug(stack[1], log_meta, function() { winston_logger.debug(stack[0], meta, callback) });
-	};
-	this.crit = this.critical = function(message, meta, callback) {
-		var log_meta = options.console !== false ? undefined : meta;
-		if (typeof(meta) == "function") {
-			callback = meta;
-		}
-		var stack = _format_stack(message);
-		winston_logger.crit(stack[1], log_meta);
-		winston_logger.crit(stack[1], log_meta, function() { winston_logger.debug(stack[0], meta, callback) });
-	};
+    if (options.filename && ! options.raw_json) {
+        fileLoggingOpts.filename = options.filename;
+        winston_logger.add(winstonDailyRotate, fileLoggingOpts);
+    } else if (options.raw_json) {
+        fileLoggingOpts.json = true;
+        winston_logger.add(winstonDailyRotate, fileLoggingOpts);
+    }
+
+    // some vodoo here; we want to automagically log a stack trace when error, debug
+    // or critical errors occur.  We essential overwrite the parent class for each
+    // method and at a stack trace
+    var methods = ['debug', 'info', 'notice', 'warning', 'error', 'crit', 'alert', 'emerg'];
+    for (var i in methods) {
+        var method = methods[i];
+        this[method] = winston_logger[method];
+    }
+
+    //this.levels = winston_logger.levels;
+    this.log = this.info = function(message, meta, callback) {
+        var log_meta = options.console !== false ? undefined : meta;
+        if (callback) {
+            winston_logger.info(message, callback);
+        }
+        else {
+            winston_logger.info(message);
+        }
+    };
+    this.warn = this.warning;
+    this.err = this.error = function(message, meta, callback) {
+        var stack = _format_stack(message);
+        var log_meta = options.console !== false ? undefined : meta;
+        if (typeof(meta) == "function") {
+            callback = meta;
+        }
+        winston_logger.error(stack[1], log_meta, function() { 
+            winston_logger.debug(stack[0], callback) 
+        });
+    };
+    this.debug = function(message, meta, callback) {
+        var log_meta = options.console !== false ? undefined : meta;
+        if (typeof(meta) == "function") {
+            callback = meta;
+        }
+        var stack = _format_stack(message);
+        winston_logger.debug(stack[1], log_meta, function() { winston_logger.debug(stack[0], meta, callback) });
+    };
+    this.crit = this.critical = function(message, meta, callback) {
+        var log_meta = options.console !== false ? undefined : meta;
+        if (typeof(meta) == "function") {
+            callback = meta;
+        }
+        var stack = _format_stack(message);
+        winston_logger.crit(stack[1], log_meta);
+        winston_logger.crit(stack[1], log_meta, function() { winston_logger.debug(stack[0], meta, callback) });
+    };
 }
 
 // for Stack tracing.  See commented out section below for customizing the output
 // of stack traces.  I'm not a big fan of altering prepareStackTrace since it is
 // a blocking operation.
 function _format_stack(message) {
-	var id = _uuid();
-	message = message + ' | trace: ' + id;
-	var error = new Error(id);
-	var stack = error.stack;
-	stack = stack.replace(/Error:\s/,'');
-	// this is somewhat hackish, but messing with prepareStackTrace can lead to blocking 
-	// problems.  Better to just strip out superfluous lines with regex
-	stack = stack.replace(/    at logger.*?\n/,'');
-	stack = stack.replace(/    at logger.*?\n/,'');
-	stack = stack.replace(/    at _format_stack.*?\n/,'');
-	return [stack,message];
+    var id = _uuid();
+    message = message + ' | trace: ' + id;
+    var error = new Error(id);
+    var stack = error.stack;
+    stack = stack.replace(/Error:\s/,'');
+    // this is somewhat hackish, but messing with prepareStackTrace can lead to blocking 
+    // problems.  Better to just strip out superfluous lines with regex
+    stack = stack.replace(/    at logger.*?\n/,'');
+    stack = stack.replace(/    at logger.*?\n/,'');
+    stack = stack.replace(/    at _format_stack.*?\n/,'');
+    return [stack,message];
 }
 
 logger.prototype.extend = function(target) {
-	var methods = ['debug', 'info', 'log', 'notice', 'warn', 'warning', 'error', 'crit', 'alert', 'emerg', 'critical'];
-	for (var i in methods) {
-		var method = methods[i];
-		target[method] = this[method];
-	}
-	return target;
+    var methods = ['debug', 'info', 'log', 'notice', 'warn', 'warning', 'error', 'crit', 'alert', 'emerg', 'critical'];
+    for (var i in methods) {
+        var method = methods[i];
+        target[method] = this[method];
+    }
+    return target;
 };
 
 // If someday you need more insight or don't like the stack trace format, you can
@@ -180,38 +142,38 @@ logger.prototype.extend = function(target) {
 // var old = Error.prepareStackTrace;
 //
 // Error.prepareStackTrace = function(error, structuredStackTrace) {
-// 	var formatted_trace = [];
-// 	structuredStackTrace.splice(0,0);
-// 	for (i in structuredStackTrace) {
-// 		var callSite = structuredStackTrace[i];
-// 		formatted_trace.push(
-//			'\t' +
-//			callSite.getTypeName()     + ' ' +
-//			callSite.getFunction()     + ' ' +
-//			callSite.getMethodName()   + ' ' +
-//			callSite.getEvalOrigin()   + ' ' +
-//			callSite.isToplevel()      + ' ' +
-//			callSite.isEval()          + ' ' +
-//			callSite.isNative()        + ' ' +
-//			callSite.isConstructor()   + ' ' +
-//		    callSite.getFileName()     + ' ' + 
-//			callSite.getFunctionName() + ' ' + 
-//			callSite.getLineNumber()   + ' ' + 
-//			callSite.getColumnNumber()
-//		);
-//	}
-//	return "\n" + formatted_trace.join("\n");
+//  var formatted_trace = [];
+//  structuredStackTrace.splice(0,0);
+//  for (i in structuredStackTrace) {
+//      var callSite = structuredStackTrace[i];
+//      formatted_trace.push(
+//          '\t' +
+//          callSite.getTypeName()     + ' ' +
+//          callSite.getFunction()     + ' ' +
+//          callSite.getMethodName()   + ' ' +
+//          callSite.getEvalOrigin()   + ' ' +
+//          callSite.isToplevel()      + ' ' +
+//          callSite.isEval()          + ' ' +
+//          callSite.isNative()        + ' ' +
+//          callSite.isConstructor()   + ' ' +
+//          callSite.getFileName()     + ' ' + 
+//          callSite.getFunctionName() + ' ' + 
+//          callSite.getLineNumber()   + ' ' + 
+//          callSite.getColumnNumber()
+//      );
+//  }
+//  return "\n" + formatted_trace.join("\n");
 //}
 //
 // //Error.prepareStackTrace = old;
 
 // util function for returning the timestamp to include in logs. 
 function _timestamp() {
-	return Strftime('%Y-%m-%d %H:%M:%S');
+    return Strftime('%Y-%m-%d %H:%M:%S');
 }
 
 function _uuid(a) {
-	return a?(0|Math.random()*16).toString(16):(""+1e7+-1e3+-4e3+-8e3+-1e11).replace(/1|0/g,_uuid);
+    return a?(0|Math.random()*16).toString(16):(""+1e7+-1e3+-4e3+-8e3+-1e11).replace(/1|0/g,_uuid);
 }
 
 module.exports = logger;

--- a/package.json
+++ b/package.json
@@ -45,12 +45,14 @@
   "dependencies": {
     "async": "^2.0.1",
     "commander": "^2.9.0",
+    "connect-requestid": "^1.1.0",
     "express": "^4.14.0",
     "fast_bindall": "0.0.1",
-    "lodash": "^4.16.2",
-	"winston": "^2.1.1",
-	"strftime": "^0.9.2",
-	"connect-requestid": "^1.1.0"
+    "mkdirp": "^0.5.1",
+    "strftime": "^0.9.2",
+    "underscore": "^1.8.3",
+    "winston": "^2.1.1",
+    "winston-daily-rotate-file": "^3.0.2"
   },
   "devDependencies": {
     "sbot": "0.0.3"


### PR DESCRIPTION
Improved log rotation by using winston-daily-rotate-file module.
Log directory should be specified in config.json (defaults to /var/log).
Ability to pass in the filename, lots of options in winston-daily-rotate-file.

Also updated missing dependencies and removed lodash.